### PR TITLE
Bump ruby version as it was not building anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6
+FROM ruby:3.3.0
 
 # install a modern bundler version
 RUN gem install bundler


### PR DESCRIPTION
Hi, you might have forgotten this project...
One of my repo is built with your action.
I hadn't committed anything for years, made a change today and the `workflow` broke...
A quick and easy fix was to bump `ruby` from image version.
I'm making this `PR`, feel free to ignore it